### PR TITLE
pkgs: add version install checks to binary packages

### DIFF
--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -2,6 +2,7 @@
 {
   buildNpmPackage,
   fetchzip,
+  versionCheckHook,
 }:
 buildNpmPackage (final: {
   pname = "claude-code";
@@ -29,6 +30,11 @@ buildNpmPackage (final: {
       --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
       --unset DEV
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/claude";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/codex/default.nix
+++ b/pkgs/codex/default.nix
@@ -3,6 +3,7 @@
   lib,
   openssl,
   stdenv,
+  versionCheckHook,
 }:
 let
   sources = lib.importJSON ./sources.json;
@@ -37,6 +38,10 @@ stdenv.mkDerivation {
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       "$out/bin/codex"
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/omnara/default.nix
+++ b/pkgs/omnara/default.nix
@@ -10,6 +10,7 @@
   lib,
   makeBinaryWrapper,
   stdenvNoCC,
+  versionCheckHook,
 }:
 let
   sources = lib.importJSON ./sources.json;
@@ -48,6 +49,10 @@ stdenvNoCC.mkDerivation {
   '';
 
   dontStrip = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = ./update.sh;
 


### PR DESCRIPTION
## Summary
- Added `versionCheckHook` to omnara, codex, and claude-code packages
- Ensures binaries are functional after installation by running `--version` during the installCheck phase
- Validates that binaries execute successfully and output correct version information

## Test plan
- [x] Built omnara package successfully - version check passed (0.13.5)
- [x] Built codex package successfully - version check passed (0.87.0)
- [x] Built claude-code package successfully - version check passed (2.0.76)

## Details
All three binary packages now include install checks that:
1. Run the binary with `--version` after installation
2. Verify the binary executes without errors
3. Check that the version output contains the expected version number
4. Fail the build early if any checks fail

This prevents broken binaries from being deployed due to missing dependencies, incorrect patching, or other packaging issues.