### PR TITLE
sops: wrap with secure editor for secret editing

### DIFF
--- a/home/mods/core.nix
+++ b/home/mods/core.nix
@@ -79,8 +79,8 @@
 
       # deploy
       phlipPkgs.rage-age-compat
+      phlipPkgs.sops
       pkgs.rage
-      pkgs.sops
       pkgs.ssh-to-age
       pkgs.yq-go
     ];

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -83,6 +83,9 @@ in
   # sampling profiler written in Rust, with native firefox-profiler integration
   samply = callPackage ./samply.nix { };
 
+  # sops wrapped with clean nvim (no plugins) for secret editing
+  sops = callPackage ./sops.nix { };
+
   # xremap - dynamic key remap for X11 and Wayland
   xremap = callPackage ./xremap.nix { };
 

--- a/pkgs/sops.nix
+++ b/pkgs/sops.nix
@@ -1,0 +1,38 @@
+# Wrapped sops with clean nvim as EDITOR.
+#
+# When editing secrets with sops, we want a minimal editor without plugins
+# (especially AI plugins like Copilot) to avoid leaking secrets.
+#
+# This wrapper sets EDITOR to clean nvim (--clean --noplugin -n).
+{
+  lib,
+  makeBinaryWrapper,
+  neovim-unwrapped,
+  runCommandLocal,
+  sops,
+}:
+let
+  # Clean nvim invocation suitable for editing secrets.
+  # --clean: skip user config + plugins
+  # --noplugin: extra insurance against plugins
+  # -n: no swap file (don't leave secrets on disk)
+  cleanNvim = "${lib.getExe neovim-unwrapped} --clean --noplugin -n";
+in
+runCommandLocal "sops-secure-${sops.version}"
+  {
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    meta = sops.meta // {
+      description = "sops wrapped with clean nvim (no plugins)";
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe sops} $out/bin/sops \
+      --set EDITOR "${cleanNvim}"
+
+    # Link all non-bin directories (share/, etc.) for completions and extras
+    for dir in ${sops}/*/; do
+      name=$(basename "$dir")
+      [[ "$name" != "bin" ]] && ln -s "$dir" "$out/$name"
+    done
+  ''


### PR DESCRIPTION
## Summary

- Wrap `sops` to set `EDITOR` to `nvim --clean --noplugin -n`
- Prevents plugins (especially AI tools like Copilot) from seeing secrets
- No swap file written to disk during editing

## Test plan

- [x] `nix build -f . phlipPkgs.sops` builds
- [x] `just nix-lint` passes
- [ ] Manual: `sops secrets.yaml` opens minimal nvim without plugins