### PR TITLE
nix: add phlip9.nix-cache module for cache.phlip9.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ $ sudo cat >> /etc/nix/nix.conf << EOF
 extra-allowed-impure-host-deps = /usr/bin/ditto
 extra-sandbox-paths = /usr/bin/ditto
 EOF
+
+# Add phlip9's nix cache
+$ sudo cat >> /etc/nix/nix.conf << EOF
+extra-substituters = https://cache.phlip9.com
+extra-trusted-public-keys = cache.phlip9.com-1:XKElS8qFXxVXcXIGFjRkGpyxiernJzHeQhMJ59VUdf4=
+EOF
 ```
 
 NOTE: this is using the unofficial DeterminateSystems nix installer.

--- a/nixos/mods/buildbot-ci.nix
+++ b/nixos/mods/buildbot-ci.nix
@@ -215,12 +215,5 @@ in
       oauth2-proxy-cookie-secret = { };
     };
 
-    # =========================================================================
-    # Use our cache for nix builds on this machine
-    # =========================================================================
-    nix.settings = {
-      extra-substituters = [ "https://${cfg.cacheDomain}" ];
-      extra-trusted-public-keys = [ cfg.cache.publicKey ];
-    };
   };
 }

--- a/nixos/mods/default.nix
+++ b/nixos/mods/default.nix
@@ -14,6 +14,7 @@
 
   (sources.sops-nix + "/modules/sops/default.nix")
   (sources.noctalia-shell + "/nix/nixos-module.nix")
+  ./nix-cache.nix
   ./phlippkgs.nix
   ./github-webhook.nix
   ./xremap.nix

--- a/nixos/mods/nix-cache.nix
+++ b/nixos/mods/nix-cache.nix
@@ -1,0 +1,18 @@
+# Configure phlip9's nix cache as an extra substituter.
+{ lib, config, ... }:
+
+let
+  cfg = config.phlip9.nix-cache;
+in
+{
+  options.phlip9.nix-cache = {
+    enable = lib.mkEnableOption "phlip9's nix cache";
+  };
+
+  config.nix.settings = lib.mkIf cfg.enable {
+    extra-substituters = [ "https://cache.phlip9.com" ];
+    extra-trusted-public-keys = [
+      "cache.phlip9.com-1:XKElS8qFXxVXcXIGFjRkGpyxiernJzHeQhMJ59VUdf4="
+    ];
+  };
+}

--- a/nixos/profiles/desktop.nix
+++ b/nixos/profiles/desktop.nix
@@ -5,6 +5,9 @@
   ...
 }:
 {
+  # Nix
+  phlip9.nix-cache.enable = true;
+
   #
   # Window/Display Manager
   #

--- a/nixos/profiles/server.nix
+++ b/nixos/profiles/server.nix
@@ -104,6 +104,8 @@
   };
 
   # Nix
+  phlip9.nix-cache.enable = true;
+
   nix = {
     # Collect garbage weekly. deletes unused items in the `/nix/store`.
     gc = {


### PR DESCRIPTION
## Summary
- Add `phlip9.nix-cache` NixOS module with `enable` option
- Enable in `nixos/profiles/desktop.nix` and `nixos/profiles/server.nix`
- Remove duplicate cache config from `buildbot-ci.nix`
- Add setup instructions to README.md for non-NixOS machines