### PR TITLE
omnara1: use prepare-commit-msg hook for co-author trailer

### DIFF
--- a/home/omnara1.nix
+++ b/home/omnara1.nix
@@ -25,16 +25,9 @@
   programs.git = {
     userName = "lexe-agent (phlip9)";
     userEmail = "admin+github.agent@lexe.app";
-    # Pre-fill commit messages with co-author trailer so commits show phlip9 as
-    # a contributor. Two leading newlines: first line for commit subject, second
-    # blank line separates subject from trailer (required for git to parse it).
-    extraConfig.commit.template = toString (
-      pkgs.writeText "git-commit-template" ''
-
-
-        Co-authored-by: Philip Kannegaard Hayes <philiphayes9@gmail.com>
-      ''
-    );
+    # Auto-append co-author trailer to all commits so they show phlip9 as a
+    # contributor. Works with `git commit -m` unlike commit.template.
+    hooks.prepare-commit-msg = ./omnara1/prepare-commit-msg;
   };
 
   # This value determines the Home Manager release that your configuration is

--- a/home/omnara1/prepare-commit-msg
+++ b/home/omnara1/prepare-commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Appends co-author trailer to commit messages if not already present.
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+# COMMIT_SOURCE="$2"  # message, template, merge, squash, commit, or empty
+# SHA1="$3"           # only set for 'commit' source (amend)
+
+COAUTHOR="Co-authored-by: Philip Kannegaard Hayes <philiphayes9@gmail.com>"
+
+# Check if trailer already exists (case-insensitive)
+if grep -qi "^Co-authored-by:.*philiphayes9@gmail.com" "$COMMIT_MSG_FILE"; then
+    exit 0
+fi
+
+# Use git interpret-trailers to properly append the trailer. This handles all
+# edge cases: adds blank line separator if needed, joins with existing trailers.
+git interpret-trailers --in-place --trailer "$COAUTHOR" "$COMMIT_MSG_FILE"


### PR DESCRIPTION
## Summary

- Replace `commit.template` with a `prepare-commit-msg` git hook
- The hook uses `git interpret-trailers` to append the co-author trailer
- Works with `git commit -m "..."` unlike `commit.template` which only works with the editor

## Test plan

- [x] Tested hook in temp repo with various commit message formats
- [x] Verified trailers are properly grouped when other trailers exist
- [x] Verified duplicate co-author is not added if already present
- [x] `just bash-lint` passes
- [x] `just nix-lint` passes
- [x] `nix build -f . homeConfigs.omnara1.activationPackage` succeeds