### PR TITLE
doc: add nixpkgs Hydra CI evaluation research

### DIFF
--- a/doc/nixpkgs-ci/01-overview.md
+++ b/doc/nixpkgs-ci/01-overview.md
@@ -1,0 +1,154 @@
+# Nixpkgs Hydra CI Evaluation Architecture
+
+This document series provides a comprehensive analysis of how nixpkgs
+structures its Nix code for Hydra CI evaluation and builds.
+
+## Document Index
+
+1. [Overview](01-overview.md) - This document
+2. [Release Entrypoints](02-release-entrypoints.md) - Main release.nix files
+3. [Release Library](03-release-lib.md) - Core library functions
+4. [Platform Filtering](04-platform-filtering.md) - How platforms are matched
+5. [Eval Error Handling](05-eval-error-handling.md) - checkMeta and failures
+6. [Job Aggregation](06-job-aggregation.md) - aggregate and channel jobs
+7. [CI Eval Infrastructure](07-ci-eval.md) - GitHub Actions eval system
+8. [Resulting Attrset Structure](08-attrset-structure.md) - Final job layout
+9. [Passthru Tests](09-passthru-tests.md) - passthru.tests handling
+
+## High-Level Architecture
+
+The nixpkgs CI evaluation system is centered around several key components:
+
+```
+                         ┌─────────────────────────────┐
+                         │  Hydra Jobset Definition    │
+                         │  (declarative.nix in Hydra) │
+                         └─────────────┬───────────────┘
+                                       │
+                                       ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                        Release Entrypoints                           │
+│  ┌────────────────┐  ┌─────────────────┐  ┌────────────────────────┐ │
+│  │ release.nix    │  │ nixos/release.  │  │ release-{cross,haskell │ │
+│  │ (Nixpkgs)      │  │ nix (NixOS)     │  │  ,python,...}.nix      │ │
+│  └───────┬────────┘  └────────┬────────┘  └───────────┬────────────┘ │
+└──────────┼────────────────────┼───────────────────────┼──────────────┘
+           │                    │                       │
+           └────────────────────┼───────────────────────┘
+                                ▼
+                    ┌───────────────────────┐
+                    │    release-lib.nix    │
+                    │  (core abstractions)  │
+                    └───────────┬───────────┘
+                                │
+        ┌───────────────────────┼───────────────────────┐
+        │                       │                       │
+        ▼                       ▼                       ▼
+┌───────────────┐     ┌─────────────────┐     ┌─────────────────────┐
+│  mapTestOn    │     │  packagePlatforms│    │   hydraJob          │
+│  (platform    │     │  (extract meta.  │    │   (strip attrs for  │
+│   mapping)    │     │   platforms)     │    │    memory savings)  │
+└───────────────┘     └─────────────────┘     └─────────────────────┘
+```
+
+## Supported Systems
+
+Defined in `ci/supportedSystems.json`:
+
+```json
+[
+  "aarch64-linux",
+  "aarch64-darwin",
+  "x86_64-linux",
+  "x86_64-darwin"
+]
+```
+
+All release files consume this centralized configuration to ensure consistency.
+
+## Key Files (relative to nixpkgs root)
+
+| File | Purpose |
+|------|---------|
+| `pkgs/top-level/release.nix` | Main Nixpkgs jobset |
+| `pkgs/top-level/release-lib.nix` | Core platform mapping functions |
+| `nixos/release.nix` | NixOS tests, images, and artifacts |
+| `nixos/release-combined.nix` | Combined NixOS+Nixpkgs channel |
+| `pkgs/top-level/release-cross.nix` | Cross-compilation smoke tests |
+| `pkgs/top-level/release-haskell.nix` | Haskell ecosystem builds |
+| `lib/customisation.nix` | `hydraJob` function definition |
+| `pkgs/build-support/release/default.nix` | `aggregate` and `channel` |
+| `pkgs/stdenv/generic/check-meta.nix` | Package validity checks |
+| `ci/eval/*.nix` | GitHub Actions evaluation infra |
+
+## Evaluation Flow
+
+1. **Hydra triggers evaluation** of a release file (e.g., `release.nix`)
+
+2. **release-lib.nix is imported** with `supportedSystems` configuration
+
+3. **Package sets are memoized** per system via `mkPkgsFor` to prevent
+   re-evaluation
+
+4. **`packagePlatforms`** recursively walks the package tree, extracting
+   `meta.hydraPlatforms` or computing from `meta.platforms - meta.badPlatforms`
+
+5. **`mapTestOn`** transforms the platform lists into actual derivation
+   references by system, producing `{ pkgName.system = drv; ... }`
+
+6. **`hydraJob`** (when `scrubJobs = true`) strips non-essential attributes
+   from derivations to reduce memory usage during evaluation
+
+7. **Aggregate jobs** combine multiple derivations into single "gating" jobs
+   that must all pass
+
+8. **Hydra builds** the resulting derivation tree, scheduling jobs per system
+
+## Memory Optimization
+
+The evaluation uses several techniques to minimize memory:
+
+```nix
+# From release-lib.nix - memoization prevents duplicate evaluations
+mkPkgsFor = crossSystem:
+  let
+    pkgs_x86_64_linux = packageSet' { system = "x86_64-linux"; };
+    pkgs_aarch64_linux = packageSet' { system = "aarch64-linux"; };
+    # ... etc
+  in
+  system:
+    if system == "x86_64-linux" then pkgs_x86_64_linux
+    # ... pattern matching to return memoized values
+```
+
+```nix
+# From lib/customisation.nix - hydraJob strips non-essential attrs
+hydraJob = drv:
+  let
+    commonAttrs = {
+      inherit (drv) name system meta;
+      inherit outputs;
+    };
+    # ... only essential attributes preserved
+  in
+  if drv == null then null else deepSeq drv' drv';
+```
+
+## Configuration Flags
+
+Key flags passed to release files:
+
+| Flag | Purpose |
+|------|---------|
+| `scrubJobs` | Strip derivation attributes to save memory |
+| `attrNamesOnly` | Return only attr names, not derivations (for CI chunking) |
+| `officialRelease` | Enable release-specific behavior |
+| `supportedSystems` | Override default platform list |
+| `nixpkgsArgs.config.allowUnfree` | Control unfree package evaluation |
+| `nixpkgsArgs.config.inHydra` | Enable Hydra-specific error handling |
+
+## References
+
+- [Hydra Manual](https://hydra.nixos.org/build/196107287/download/1/hydra/index.html)
+- [nixpkgs Hydra Instance](https://hydra.nixos.org/project/nixpkgs)
+- [NixOS Hydra Instance](https://hydra.nixos.org/project/nixos)

--- a/doc/nixpkgs-ci/02-release-entrypoints.md
+++ b/doc/nixpkgs-ci/02-release-entrypoints.md
@@ -1,0 +1,327 @@
+# Release Entrypoints
+
+This document covers the main release.nix files that serve as entrypoints for
+Hydra jobsets.
+
+## pkgs/top-level/release.nix - Main Nixpkgs Jobset
+
+**File:** `pkgs/top-level/release.nix` (402 lines)
+
+This is the primary entrypoint for building Nixpkgs packages.
+
+### Function Signature
+
+```nix
+{
+  nixpkgs ? {
+    outPath = (import ../../lib).cleanSource ../..;
+    revCount = 1234;
+    shortRev = "abcdef";
+    revision = "0000000000000000000000000000000000000000";
+  },
+  system ? builtins.currentSystem,
+  officialRelease ? false,
+  supportedSystems ? builtins.fromJSON (builtins.readFile ../../ci/supportedSystems.json),
+  bootstrapConfigs ? [ ... ],  # Platform triples for bootstrap tools
+  scrubJobs ? true,
+  nixpkgsArgs ? {
+    config = {
+      allowAliases = false;
+      allowUnfree = false;
+      inHydra = true;
+      permittedInsecurePackages = [ ... ];
+    };
+    __allowFileset = false;
+  },
+  attrNamesOnly ? false,  # For CI eval optimization
+}:
+```
+
+### Job Structure
+
+The output is composed of two parts joined with `unionOfDisjoint`:
+
+```nix
+jobs = unionOfDisjoint nonPackageJobs mapTestOn-packages;
+```
+
+#### Non-Package Jobs
+
+Special release-critical jobs that aren't simple package builds:
+
+```nix
+nonPackageJobs = {
+  # Source tarball with version info and packages.json index
+  tarball = import ./make-tarball.nix { ... };
+
+  # Validation: no <nixpkgs> references, case sensitivity, warnings
+  release-checks = import ./nixpkgs-basic-release-checks.nix { ... };
+
+  # Documentation
+  manual = pkgs.nixpkgs-manual.override { inherit nixpkgs; };
+
+  # Performance metrics tracking
+  metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
+
+  # Darwin aggregate gate
+  darwin-tested = pkgs.releaseTools.aggregate { ... };
+
+  # Unstable channel aggregate gate
+  unstable = pkgs.releaseTools.aggregate { ... };
+
+  # Bootstrap toolchains for all platforms
+  stdenvBootstrapTools = genAttrs bootstrapConfigs ( ... );
+};
+```
+
+#### Package Jobs
+
+All packages mapped to their supported platforms:
+
+```nix
+packageJobs = packagePlatforms pkgs // {
+  # Multi-GHC Haskell Language Server builds
+  haskell = packagePlatforms pkgs.haskell // {
+    packages = genAttrs [ "ghc96" "ghc98" "ghc910" "ghc912" ] ( ... );
+  };
+
+  # Alternative toolchain stdenvs
+  pkgsLLVM.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+  pkgsArocc.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+  pkgsZig.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+  pkgsMusl.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+  pkgsStatic.stdenv = [ "x86_64-linux" "aarch64-linux" ];
+
+  # ROCm packages use their own release mechanism
+  pkgsRocm = pkgs.rocmPackages.meta.release-packagePlatforms;
+};
+```
+
+### Aggregate Jobs Example
+
+The `unstable` aggregate defines what must pass for channel updates:
+
+```nix
+unstable = pkgs.releaseTools.aggregate {
+  name = "nixpkgs-${jobs.tarball.version}";
+  meta.description = "Release-critical builds for the Nixpkgs unstable channel";
+  constituents = [
+    jobs.tarball
+    jobs.release-checks
+    jobs.metrics
+    jobs.manual
+    jobs.tests.lib-tests.x86_64-linux
+    jobs.stdenv.x86_64-linux
+    jobs.cargo.x86_64-linux
+    jobs.go.x86_64-linux
+    jobs.linux.x86_64-linux
+    jobs.nix.x86_64-linux
+    jobs.python3.x86_64-linux
+    jobs.firefox-unwrapped.x86_64-linux
+    # ... more critical packages
+  ]
+  ++ collect isDerivation jobs.stdenvBootstrapTools
+  ++ optionals supportDarwin.x86_64 [ ... ]
+  ++ optionals supportDarwin.aarch64 [ ... ];
+};
+```
+
+## nixos/release.nix - NixOS Artifacts
+
+**File:** `nixos/release.nix` (566 lines)
+
+Builds NixOS-specific artifacts: ISOs, VM images, tests.
+
+### Key Structure
+
+```nix
+{
+  nixpkgs ? { ... },
+  stableBranch ? false,
+  supportedSystems ? [ "x86_64-linux" "aarch64-linux" ],
+  configuration ? { },
+  attrNamesOnly ? false,
+}:
+```
+
+### Test Discovery
+
+Tests are discovered from `nixos/tests/all-tests.nix`:
+
+```nix
+allTestsForSystem = system:
+  import ./tests/all-tests.nix {
+    inherit system;
+    pkgs = import ./.. { inherit system; };
+    callTest = config:
+      if attrNamesOnly then hydraJob config.test
+      else { ${system} = hydraJob config.test; };
+  };
+
+allTests = foldAttrs recursiveUpdate { }
+  (map allTestsForSystem
+    (if attrNamesOnly then [ (head supportedSystems) ] else supportedSystems));
+```
+
+### Build Outputs
+
+```nix
+{
+  channel = import lib/make-channel.nix { ... };
+
+  # Documentation
+  manualHTML = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualHTML);
+  manualEpub = ...;
+  options = ...;
+
+  # Installation media
+  iso_minimal = forAllSystems (system: makeIso { ... });
+  iso_graphical = forAllSystems (system: makeIso { ... });
+
+  # SD card images (ARM)
+  sd_image = forMatchingSystems [ "armv6l-linux" "armv7l-linux" "aarch64-linux" ] ...;
+
+  # Cloud images
+  amazonImage = forMatchingSystems [ "x86_64-linux" "aarch64-linux" ] ...;
+  proxmoxImage = forMatchingSystems [ "x86_64-linux" ] ...;
+  incusContainerImage = forMatchingSystems [ "x86_64-linux" "aarch64-linux" ] ...;
+
+  # Network boot
+  netboot = forMatchingSystems supportedSystems ...;
+  kexec = forMatchingSystems supportedSystems ...;
+
+  # All tests
+  tests = allTests;
+
+  # Closure size tracking
+  closures = {
+    smallContainer = makeClosure ( ... );
+    tinyContainer = makeClosure ( ... );
+    kde = makeClosure ( ... );
+    gnome = makeClosure ( ... );
+    # ...
+  };
+}
+```
+
+## nixos/release-combined.nix - Channel Gating
+
+**File:** `nixos/release-combined.nix` (199 lines)
+
+Combines NixOS and Nixpkgs into a single jobset for channel updates.
+
+```nix
+{
+  nixos = removeMaintainers (import ./release.nix { ... });
+  nixpkgs = removeAttrs (removeMaintainers (import ../pkgs/top-level/release.nix { ... }))
+    [ "unstable" ];
+
+  tested = pkgs.releaseTools.aggregate {
+    name = "nixos-${nixos.channel.version}";
+    constituents = [
+      "nixos.channel"
+      (onFullSupported "nixos.iso_minimal")
+      (onFullSupported "nixos.tests.login")
+      (onFullSupported "nixos.tests.openssh")
+      # ... comprehensive test list
+      [ "nixpkgs.tarball" "nixpkgs.release-checks" ]
+    ];
+  };
+}
+```
+
+## Specialized Release Files
+
+### release-small.nix
+
+Minimal jobset for `stdenv-updates` branch testing:
+
+```nix
+# ~50 essential packages only
+{
+  tarball = import ./make-tarball.nix { ... };
+}
+// (mapTestOn {
+  aspell = all;
+  bash = all;
+  gcc = all;
+  glibc = linux;
+  nix = all;
+  python3 = unix;
+  stdenv = all;
+  # ...
+})
+```
+
+### release-staging.nix
+
+Even more minimal - just stdenv on all platforms for staging merges.
+
+### release-cross.nix
+
+Cross-compilation smoke tests for ~30 target platforms:
+
+```nix
+{
+  crossMingw32 = mapTestOnCross systems.examples.mingw-msvcrt-i686 windowsCommon;
+  aarch64 = mapTestOnCross systems.examples.aarch64-multiplatform linuxCommon;
+  riscv64 = mapTestOnCross systems.examples.riscv64 linuxCommon;
+  wasi32 = mapTestOnCross systems.examples.wasi32 wasiCommon;
+  arm-embedded = mapTestOnCross systems.examples.arm-embedded embedded;
+  # ... many more
+  bootstrapTools = { ... };  # Cross-built bootstrap tools
+}
+```
+
+### release-haskell.nix
+
+Multi-compiler Haskell package testing:
+
+```nix
+released = [ "ghc948" "ghc967" "ghc984" "ghc9102" "ghc9103" "ghc9122" "ghc9123" ];
+
+jobs = recursiveUpdateMany [
+  (mapTestOn {
+    haskellPackages = packagePlatforms pkgs.haskellPackages;
+    haskell.compiler = packagePlatforms pkgs.haskell.compiler;
+    # top-level Haskell-dependent packages
+    inherit (pkgsPlatforms) pandoc stack shellcheck ...;
+  })
+  (versionedCompilerJobs {
+    haskell-language-server = released;
+    cabal-install = lib.subtractLists [ ... ] released;
+    # ...
+  })
+  {
+    mergeable = pkgs.releaseTools.aggregate { ... };
+    maintained = pkgs.releaseTools.aggregate { ... };
+  }
+];
+```
+
+### release-python.nix
+
+Python package testing with recursive discovery:
+
+```nix
+packagePython = mapAttrs (name: value:
+  let res = builtins.tryEval (
+    if isDerivation value then
+      value.meta.isBuildPythonPackage or [ ]
+    else if value.recurseForDerivations or false || value.recurseForRelease or false then
+      packagePython value
+    else [ ]
+  );
+  in optionals res.success res.value
+);
+
+jobs = {
+  tested = pkgs.releaseTools.aggregate {
+    constituents = [
+      jobs.python313Packages.sphinx.x86_64-linux
+      jobs.python313Packages.requests.x86_64-linux
+      # ...
+    ];
+  };
+} // (mapTestOn (packagePython pkgs));
+```

--- a/doc/nixpkgs-ci/03-release-lib.md
+++ b/doc/nixpkgs-ci/03-release-lib.md
@@ -1,0 +1,306 @@
+# Release Library (release-lib.nix)
+
+**File:** `pkgs/top-level/release-lib.nix` (263 lines)
+
+This module provides the core abstractions for mapping packages to their
+supported platforms and constructing the Hydra job tree.
+
+## Module Interface
+
+```nix
+{
+  supportedSystems,
+  system ? builtins.currentSystem,
+  packageSet ? (import ../..),
+  scrubJobs ? true,
+  nixpkgsArgs ? { ... },
+}:
+```
+
+## Package Set Memoization
+
+The key optimization is memoizing package set instantiation per system. Without
+this, Nixpkgs would be re-evaluated for every package/platform combination.
+
+```nix
+mkPkgsFor = crossSystem:
+  let
+    packageSet' = args: packageSet (args // { inherit crossSystem; } // nixpkgsArgs);
+
+    # Pre-instantiate all supported systems
+    pkgs_x86_64_linux = packageSet' { system = "x86_64-linux"; };
+    pkgs_i686_linux = packageSet' { system = "i686-linux"; };
+    pkgs_aarch64_linux = packageSet' { system = "aarch64-linux"; };
+    pkgs_riscv64_linux = packageSet' { system = "riscv64-linux"; };
+    pkgs_aarch64_darwin = packageSet' { system = "aarch64-darwin"; };
+    pkgs_armv6l_linux = packageSet' { system = "armv6l-linux"; };
+    pkgs_armv7l_linux = packageSet' { system = "armv7l-linux"; };
+    pkgs_x86_64_darwin = packageSet' { system = "x86_64-darwin"; };
+    pkgs_x86_64_freebsd = packageSet' { system = "x86_64-freebsd"; };
+    pkgs_i686_freebsd = packageSet' { system = "i686-freebsd"; };
+    pkgs_i686_cygwin = packageSet' { system = "i686-cygwin"; };
+    pkgs_x86_64_cygwin = packageSet' { system = "x86_64-cygwin"; };
+  in
+  system:
+    if system == "x86_64-linux" then pkgs_x86_64_linux
+    else if system == "i686-linux" then pkgs_i686_linux
+    else if system == "aarch64-linux" then pkgs_aarch64_linux
+    else if system == "riscv64-linux" then pkgs_riscv64_linux
+    else if system == "aarch64-darwin" then pkgs_aarch64_darwin
+    else if system == "armv6l-linux" then pkgs_armv6l_linux
+    else if system == "armv7l-linux" then pkgs_armv7l_linux
+    else if system == "x86_64-darwin" then pkgs_x86_64_darwin
+    else if system == "x86_64-freebsd" then pkgs_x86_64_freebsd
+    else if system == "i686-freebsd" then pkgs_i686_freebsd
+    else if system == "i686-cygwin" then pkgs_i686_cygwin
+    else if system == "x86_64-cygwin" then pkgs_x86_64_cygwin
+    else abort "unsupported system type: ${system}";
+
+# Native compilation
+pkgsFor = pkgsForCross null;
+
+# Cross compilation with additional memoization
+pkgsForCross =
+  let
+    examplesByConfig = flip mapAttrs' systems.examples (
+      _: crossSystem: nameValuePair crossSystem.config {
+        inherit crossSystem;
+        pkgsFor = mkPkgsFor crossSystem;
+      }
+    );
+    native = mkPkgsFor null;
+  in
+  crossSystem:
+    let candidate = examplesByConfig.${crossSystem.config} or null;
+    in
+    if crossSystem == null then native
+    else if candidate != null && matchAttrs crossSystem candidate.crossSystem then
+      candidate.pkgsFor
+    else mkPkgsFor crossSystem;  # uncached fallback
+```
+
+## Platform Matching
+
+### supportedMatches
+
+Filters `supportedSystems` to those matching platform patterns:
+
+```nix
+supportedMatches =
+  let
+    supportedPlatforms = map (system: systems.elaborate { inherit system; }) supportedSystems;
+  in
+  metaPatterns:
+    let
+      anyMatch = platform: any (meta.platformMatch platform) metaPatterns;
+      matchingPlatforms = filter anyMatch supportedPlatforms;
+    in
+    map ({ system, ... }: system) matchingPlatforms;
+```
+
+### forMatchingSystems
+
+Generate attributes for systems matching patterns:
+
+```nix
+forMatchingSystems = metaPatterns: genAttrs (supportedMatches metaPatterns);
+```
+
+## Core Mapping Functions
+
+### testOn / testOnCross
+
+Build a package on matching platforms:
+
+```nix
+# Native builds
+testOn = testOnCross null;
+
+# Cross builds
+testOnCross = crossSystem: metaPatterns: f:
+  forMatchingSystems metaPatterns (system:
+    hydraJob' (f (pkgsForCross crossSystem system))
+  );
+```
+
+Usage example:
+```nix
+# Build hello on all Linux systems
+helloJobs = testOn linux (pkgs: pkgs.hello);
+# Result: { x86_64-linux = <drv>; aarch64-linux = <drv>; ... }
+```
+
+### mapTestOn
+
+The key function that transforms a nested attrset of platform lists into
+actual derivations:
+
+```nix
+mapTestOn = _mapTestOnHelper id null;
+
+_mapTestOnHelper = f: crossSystem:
+  mapAttrsRecursive (path: metaPatterns:
+    testOnCross crossSystem metaPatterns (pkgs:
+      f (getAttrFromPath path pkgs)
+    )
+  );
+```
+
+Usage:
+```nix
+mapTestOn {
+  hello = [ "x86_64-linux" "aarch64-linux" ];
+  nested.package = [ "x86_64-darwin" ];
+}
+# Result:
+# {
+#   hello.x86_64-linux = <drv>;
+#   hello.aarch64-linux = <drv>;
+#   nested.package.x86_64-darwin = <drv>;
+# }
+```
+
+### mapTestOnCross
+
+For cross-compilation with maintainer metadata:
+
+```nix
+mapTestOnCross = _mapTestOnHelper (addMetaAttrs {
+  maintainers = crossMaintainers;
+});
+```
+
+## Package Platform Extraction
+
+### getPlatforms
+
+Extract the list of platforms a derivation should build on:
+
+```nix
+getPlatforms = drv:
+  drv.meta.hydraPlatforms
+    or (subtractLists (drv.meta.badPlatforms or [ ])
+                      (drv.meta.platforms or supportedSystems));
+```
+
+Priority order:
+1. `meta.hydraPlatforms` - explicit Hydra platform list (if set)
+2. `meta.platforms - meta.badPlatforms` - computed from platform metadata
+3. `supportedSystems` - fallback to all supported systems
+
+### recursiveMapPackages
+
+Recursively map a function over all derivations in a package set:
+
+```nix
+recursiveMapPackages = f:
+  mapAttrs (name: value:
+    if isDerivation value then
+      f value
+    else if value.recurseForDerivations or false || value.recurseForRelease or false then
+      recursiveMapPackages f value
+    else
+      [ ]
+  );
+```
+
+The recursion respects two flags:
+- `recurseForDerivations` - standard Nixpkgs recursion marker
+- `recurseForRelease` - Hydra-specific recursion marker
+
+### packagePlatforms
+
+Combines the above to extract platforms for all packages:
+
+```nix
+packagePlatforms = recursiveMapPackages getPlatforms;
+```
+
+Example output:
+```nix
+{
+  hello = [ "aarch64-linux" "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  pythonPackages = {
+    requests = [ "aarch64-linux" "x86_64-linux" ];
+    # ...
+  };
+}
+```
+
+## The hydraJob Function
+
+When `scrubJobs = true`, derivations are wrapped with `hydraJob`:
+
+```nix
+hydraJob' = if scrubJobs then hydraJob else id;
+```
+
+The actual `hydraJob` function (from `lib/customisation.nix`):
+
+```nix
+hydraJob = drv:
+  let
+    outputs = drv.outputs or [ "out" ];
+
+    commonAttrs = {
+      inherit (drv) name system meta;
+      inherit outputs;
+    }
+    // optionalAttrs (drv._hydraAggregate or false) {
+      _hydraAggregate = true;
+      constituents = map hydraJob (flatten drv.constituents);
+    }
+    // (listToAttrs outputsList);
+
+    makeOutput = outputName:
+      let output = drv.${outputName};
+      in {
+        name = outputName;
+        value = commonAttrs // {
+          outPath = output.outPath;
+          drvPath = output.drvPath;
+          type = "derivation";
+          inherit outputName;
+        };
+      };
+
+    outputsList = map makeOutput outputs;
+    drv' = (head outputsList).value;
+  in
+  if drv == null then null else deepSeq drv' drv';
+```
+
+Key characteristics:
+- Preserves only: `name`, `system`, `meta`, `outputs`, output paths
+- Strips all build-time attributes (src, buildInputs, etc.)
+- Uses `deepSeq` to force evaluation and enable GC of intermediate values
+- Handles aggregate jobs via `_hydraAggregate` flag
+
+## Module Exports
+
+```nix
+{
+  # Platform groups
+  inherit (platforms) unix linux darwin cygwin all;
+
+  # Core functions
+  inherit
+    assertTrue
+    forAllSystems
+    forMatchingSystems
+    hydraJob'
+    lib
+    mapTestOn
+    mapTestOnCross
+    recursiveMapPackages
+    getPlatforms
+    packagePlatforms
+    pkgs
+    pkgsFor
+    pkgsForCross
+    supportedMatches
+    testOn
+    testOnCross
+    ;
+}
+```

--- a/doc/nixpkgs-ci/04-platform-filtering.md
+++ b/doc/nixpkgs-ci/04-platform-filtering.md
@@ -1,0 +1,268 @@
+# Platform Filtering
+
+This document explains how nixpkgs determines which platforms a package should
+be built on for Hydra CI.
+
+## Meta Attributes for Platform Control
+
+### meta.platforms
+
+Specifies platforms where the package is expected to work:
+
+```nix
+stdenv.mkDerivation {
+  # ...
+  meta.platforms = lib.platforms.linux;
+  # or
+  meta.platforms = [ "x86_64-linux" "aarch64-linux" ];
+  # or using platform patterns
+  meta.platforms = lib.platforms.unix;
+}
+```
+
+### meta.badPlatforms
+
+Platforms where the package is known to be broken:
+
+```nix
+meta = {
+  platforms = lib.platforms.unix;
+  badPlatforms = [ "aarch64-darwin" ];  # Broken on Apple Silicon
+};
+```
+
+### meta.hydraPlatforms
+
+Explicitly override which platforms Hydra builds on. Takes precedence over
+`platforms` and `badPlatforms`:
+
+```nix
+meta = {
+  platforms = lib.platforms.all;
+  hydraPlatforms = [ "x86_64-linux" ];  # Only build on x86_64-linux for Hydra
+};
+
+# To disable Hydra builds entirely:
+meta.hydraPlatforms = [ ];
+```
+
+The `lib.meta.dontDistribute` helper sets `hydraPlatforms = []`:
+
+```nix
+# From lib/meta.nix
+dontDistribute = drv: addMetaAttrs { hydraPlatforms = [ ]; } drv;
+```
+
+## Platform Resolution Logic
+
+From `release-lib.nix`:
+
+```nix
+getPlatforms = drv:
+  drv.meta.hydraPlatforms
+    or (subtractLists (drv.meta.badPlatforms or [ ])
+                      (drv.meta.platforms or supportedSystems));
+```
+
+Resolution order:
+1. If `meta.hydraPlatforms` is set, use it directly
+2. Otherwise, compute: `meta.platforms - meta.badPlatforms`
+3. If `meta.platforms` is unset, default to all `supportedSystems`
+
+## Platform Matching (lib/meta.nix)
+
+### platformMatch
+
+Matches a platform against a pattern:
+
+```nix
+platformMatch = platform: elem:
+  # Optimization: string comparison for simple platform strings
+  if isString elem then
+    platform ? system && elem == platform.system
+  else
+    # For structured platform patterns, use matchAttrs
+    matchAttrs (
+      if elem ? parsed then elem else { parsed = elem; }
+    ) platform;
+```
+
+Three pattern types are supported:
+
+1. **Legacy string**: `"x86_64-linux"`
+2. **Platform structure pattern**: `{ parsed = { ... }; }`
+3. **Parsed field pattern**: `{ cpu = { family = "x86"; }; }`
+
+### availableOn
+
+Check if a package is available on a given platform:
+
+```nix
+availableOn = platform: pkg:
+  ((!pkg ? meta.platforms) || any (platformMatch platform) pkg.meta.platforms)
+  && all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or [ ]);
+```
+
+## Platform Groups (lib/systems/platforms.nix)
+
+Common platform groups used in `meta.platforms`:
+
+```nix
+# From lib/platforms.nix (re-exported from lib/systems/platforms.nix)
+{
+  all = [];  # Empty means "all platforms" in meta.platforms context
+
+  linux = [
+    "aarch64-linux"
+    "armv5tel-linux"
+    "armv6l-linux"
+    "armv7a-linux"
+    "armv7l-linux"
+    "i686-linux"
+    "loongarch64-linux"
+    "m68k-linux"
+    "microblaze-linux"
+    "mips64el-linux"
+    "mipsel-linux"
+    "powerpc64-linux"
+    "powerpc64le-linux"
+    "riscv32-linux"
+    "riscv64-linux"
+    "s390-linux"
+    "s390x-linux"
+    "x86_64-linux"
+  ];
+
+  darwin = [ "aarch64-darwin" "x86_64-darwin" ];
+
+  unix = linux ++ darwin ++ freebsd ++ netbsd ++ openbsd;
+
+  # Note: 'none' is different from empty list
+  none = [];
+}
+```
+
+## Structured Platform Patterns
+
+For more precise platform matching:
+
+```nix
+# Match all ARM Linux platforms
+meta.platforms = [
+  { parsed = { kernel = { name = "linux"; }; cpu = { family = "arm"; }; }; }
+];
+
+# Using lib.systems.inspect.patterns
+meta.platforms = [ lib.systems.inspect.patterns.isLinux ];
+```
+
+## Release-Lib Platform Filtering
+
+### supportedMatches
+
+Filters `supportedSystems` to those matching patterns:
+
+```nix
+supportedMatches =
+  let
+    supportedPlatforms = map (system: systems.elaborate { inherit system; })
+                             supportedSystems;
+  in
+  metaPatterns:
+    let
+      anyMatch = platform: any (meta.platformMatch platform) metaPatterns;
+      matchingPlatforms = filter anyMatch supportedPlatforms;
+    in
+    map ({ system, ... }: system) matchingPlatforms;
+```
+
+### forMatchingSystems
+
+Generate job attributes only for matching systems:
+
+```nix
+forMatchingSystems = metaPatterns: genAttrs (supportedMatches metaPatterns);
+
+# Example: Build only on x86_64-linux
+sdImage = forMatchingSystems [ "x86_64-linux" ] (system: makeSdImage { ... });
+```
+
+## Examples
+
+### Package with broad platform support
+
+```nix
+stdenv.mkDerivation {
+  pname = "hello";
+  # ...
+  meta.platforms = lib.platforms.unix;
+}
+# Will build on: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin
+```
+
+### Linux-only package
+
+```nix
+meta.platforms = lib.platforms.linux;
+# Will build on: x86_64-linux, aarch64-linux (from supportedSystems)
+```
+
+### Package with known broken platform
+
+```nix
+meta = {
+  platforms = lib.platforms.unix;
+  badPlatforms = lib.platforms.darwin;  # Broken on macOS
+};
+# Will build on: x86_64-linux, aarch64-linux
+```
+
+### Package only for Hydra cache, not supported
+
+```nix
+meta = {
+  platforms = [ "x86_64-linux" ];
+  hydraPlatforms = [ "x86_64-linux" "aarch64-linux" ];
+};
+# meta.platforms says only x86_64 is "supported"
+# But hydraPlatforms overrides for Hydra to build on both
+```
+
+### Disable Hydra builds
+
+```nix
+meta = {
+  platforms = lib.platforms.linux;
+  hydraPlatforms = [ ];  # Don't build on Hydra
+};
+# or use:
+lib.meta.dontDistribute myPackage
+```
+
+## check-meta.nix Platform Checks
+
+When `config.checkMeta = true`, packages are validated:
+
+```nix
+# From pkgs/stdenv/generic/check-meta.nix
+hasUnsupportedPlatform = pkg: !(availableOn hostPlatform pkg);
+
+checkValidity = attrs:
+  # ...
+  if hasUnsupportedPlatform attrs && !allowUnsupportedSystem then
+    {
+      reason = "unsupported";
+      errormsg = ''
+        is not available on the requested hostPlatform:
+          hostPlatform.system = "${hostPlatform.system}"
+          package.meta.platforms = ${toPretty' (attrs.meta.platforms or [ ])}
+          package.meta.badPlatforms = ${toPretty' (attrs.meta.badPlatforms or [ ])}
+      '';
+      # ...
+    }
+  # ...
+```
+
+This check can be bypassed with:
+- `config.allowUnsupportedSystem = true`
+- `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1` environment variable

--- a/doc/nixpkgs-ci/05-eval-error-handling.md
+++ b/doc/nixpkgs-ci/05-eval-error-handling.md
@@ -1,0 +1,287 @@
+# Evaluation Error Handling
+
+This document covers how nixpkgs handles evaluation failures, broken packages,
+and the `checkMeta` system.
+
+## check-meta.nix Overview
+
+**File:** `pkgs/stdenv/generic/check-meta.nix` (744 lines)
+
+This module validates derivation metadata and attributes, controlling which
+packages are allowed to evaluate based on various criteria.
+
+## Validity Checks
+
+### Check Categories
+
+The `checkValidity` function returns one of:
+- `null` - Package is valid
+- `{ reason; errormsg; remediation; }` - Package failed validation
+
+```nix
+checkValidity = attrs:
+  # Fatal errors (cannot be ignored)
+  if metaInvalid (attrs.meta or { }) then
+    { reason = "unknown-meta"; ... }
+  else if checkOutputsToInstall attrs then
+    { reason = "broken-outputs"; ... }
+
+  # Ignorable errors
+  else if hasDeniedUnfreeLicense attrs && !(hasAllowlistedLicense attrs) then
+    { reason = "unfree"; ... }
+  else if hasBlocklistedLicense attrs then
+    { reason = "blocklisted"; ... }
+  else if hasDeniedNonSourceProvenance attrs then
+    { reason = "non-source"; ... }
+  else if hasDeniedBroken attrs then
+    { reason = "broken"; ... }
+  else if hasUnsupportedPlatform attrs && !allowUnsupportedSystem then
+    { reason = "unsupported"; ... }
+  else if hasDisallowedInsecure attrs then
+    { reason = "insecure"; ... }
+  else
+    null;
+```
+
+### Reason Strings
+
+These reason strings are used by ofBorg and other CI tools:
+
+| Reason | Meaning |
+|--------|---------|
+| `unknown-meta` | Invalid meta attribute types |
+| `broken-outputs` | `meta.outputsToInstall` references non-existent outputs |
+| `unfree` | Unfree license and not allowed |
+| `blocklisted` | License is explicitly blocklisted |
+| `non-source` | Binary/non-source package and not allowed |
+| `broken` | `meta.broken = true` |
+| `unsupported` | Platform not in `meta.platforms` or in `meta.badPlatforms` |
+| `insecure` | `meta.knownVulnerabilities` is non-empty |
+
+## handleEvalIssue Configuration
+
+The `config.handleEvalIssue` function allows custom handling of eval failures:
+
+```nix
+# From ci/eval/outpaths.nix
+nixpkgsArgs = {
+  config = {
+    checkMeta = true;
+    handleEvalIssue = reason: errormsg:
+      let
+        fatalErrors = [ "unknown-meta" "broken-outputs" ];
+      in
+      if builtins.elem reason fatalErrors then
+        abort errormsg
+      else if !includeBroken && builtins.elem reason [ "broken" "unfree" ] then
+        throw "broken"
+      else if builtins.elem reason [ "unsupported" ] then
+        throw "unsupported"
+      else
+        true;
+
+    inHydra = true;
+  };
+};
+```
+
+### Hydra Behavior
+
+When `config.inHydra = true`:
+- Error messages are shortened
+- `throw` is used instead of `abort` for recoverable errors
+- ofBorg can catch and categorize failures
+
+```nix
+# From check-meta.nix
+inHydra = config.inHydra or false;
+
+# Error message format differs
+msg = if inHydra then
+  "Failed to evaluate ${getNameWithVersion attrs}: «${invalid.reason}»: ${invalid.errormsg}"
+else
+  ''
+    Package '${getNameWithVersion attrs}' in ${pos_str meta} ${invalid.errormsg}, refusing to evaluate.
+  '' + invalid.remediation;
+```
+
+## Meta Type Validation
+
+When `config.checkMeta = true`, meta attribute types are validated:
+
+```nix
+metaTypes = {
+  description = str;
+  mainProgram = str;
+  longDescription = str;
+  homepage = union [ (listOf str) str ];
+  license = union [ (listOf licenseType) licenseType ];
+  maintainers = listOf (attrsOf any);
+  platforms = platforms;
+  hydraPlatforms = listOf str;
+  broken = bool;
+  tests = { name = "test"; verify = x: x == {} || (isDerivation x && x ? meta.timeout); };
+  # ... many more
+};
+
+checkMetaAttr = k: v:
+  if metaTypes ? ${k} then
+    if metaTypes'.${k} v then [ ]
+    else [ "key 'meta.${k}' has invalid value; expected ${metaTypes.${k}.name}, got\n    ${toPretty v}" ]
+  else
+    [ "key 'meta.${k}' is unrecognized; expected one of: [${...}]" ];
+```
+
+## Allow Predicates
+
+Fine-grained control over what packages are allowed:
+
+### allowUnfreePredicate
+
+```nix
+{
+  config.allowUnfree = false;
+  config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [ "vscode" "nvidia-x11" ];
+}
+```
+
+### allowBrokenPredicate
+
+```nix
+{
+  config.allowBroken = false;
+  config.allowBrokenPredicate = pkg:
+    builtins.elem (lib.getName pkg) [ "some-temporarily-broken-pkg" ];
+}
+```
+
+### allowInsecurePredicate / permittedInsecurePackages
+
+```nix
+{
+  config.permittedInsecurePackages = [
+    "openssl-1.0.2u"
+  ];
+  # or
+  config.allowInsecurePredicate = pkg:
+    pkg.pname == "openssl" && lib.hasPrefix "1.0" pkg.version;
+}
+```
+
+## Environment Variables
+
+Override checks via environment:
+
+| Variable | Effect |
+|----------|--------|
+| `NIXPKGS_ALLOW_UNFREE=1` | Allow unfree packages |
+| `NIXPKGS_ALLOW_BROKEN=1` | Allow broken packages |
+| `NIXPKGS_ALLOW_INSECURE=1` | Allow insecure packages |
+| `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1` | Allow unsupported platforms |
+| `NIXPKGS_ALLOW_NONSOURCE=1` | Allow binary packages |
+
+## assertValidity Function
+
+The final check that determines if a package can be evaluated:
+
+```nix
+assertValidity = { meta, attrs }:
+  let
+    invalid = checkValidity attrs;
+    warning = checkWarnings attrs;
+  in
+  if isNull invalid then
+    if isNull warning then
+      { valid = "yes"; handled = true; }
+    else
+      # Warnings don't block evaluation
+      warning // { valid = "warn"; handled = ...; }
+  else
+    let
+      handled = if config ? handleEvalIssue
+        then config.handleEvalIssue invalid.reason msg
+        else throw msg;
+    in
+    invalid // { valid = "no"; handled = handled; };
+```
+
+The result is used in `commonMeta`:
+
+```nix
+commonMeta = { validity, attrs, pos, references }:
+  {
+    # ... other meta fields ...
+
+    # Expose check results
+    unfree = hasUnfreeLicense attrs;
+    broken = isMarkedBroken attrs;
+    unsupported = hasUnsupportedPlatform attrs;
+    insecure = isMarkedInsecure attrs;
+
+    available = validity.valid != "no"
+      && ((config.checkMetaRecursively or false) ->
+          all (d: d.meta.available or true) references);
+  };
+```
+
+## CI Evaluation Error Handling
+
+### builtins.tryEval Usage
+
+For packages that might fail to evaluate:
+
+```nix
+# From release-python.nix
+packagePython = mapAttrs (name: value:
+  let
+    res = builtins.tryEval (
+      if isDerivation value then
+        value.meta.isBuildPythonPackage or [ ]
+      else if value.recurseForDerivations or false then
+        packagePython value
+      else
+        [ ]
+    );
+  in
+  optionals res.success res.value
+);
+```
+
+### Hydra's Behavior
+
+Hydra uses `nix-instantiate` or `hydra-eval-jobs` which:
+1. Catches `throw` exceptions and marks the job as "eval failed"
+2. Propagates `abort` exceptions, failing the entire evaluation
+3. Records the error message for display in the web UI
+
+This is why `handleEvalIssue` uses:
+- `abort` for fatal errors that indicate Nixpkgs bugs
+- `throw` for expected failures (broken, unsupported, etc.)
+- `true` to silently skip (e.g., unfree packages in Hydra)
+
+## Warning Checks
+
+Non-fatal warnings that don't block evaluation:
+
+```nix
+checkWarnings = attrs:
+  if hasNoMaintainers attrs then
+    { reason = "maintainerless"; errormsg = "has no maintainers or teams"; ... }
+  else
+    null;
+
+hasNoMaintainers = attrs:
+  (!attrs ? outputHash)  # Not a FOD
+  && (attrs ? meta.description)  # Looks like a real package
+  && (attrs.meta.maintainers or [ ] == [ ])
+  && (attrs.meta.teams or [ ] == [ ]);
+```
+
+Warnings are only shown when explicitly enabled:
+
+```nix
+{
+  config.showDerivationWarnings = [ "maintainerless" ];
+}
+```

--- a/doc/nixpkgs-ci/06-job-aggregation.md
+++ b/doc/nixpkgs-ci/06-job-aggregation.md
@@ -1,0 +1,292 @@
+# Job Aggregation
+
+This document covers how nixpkgs creates aggregate jobs and channel artifacts
+for Hydra.
+
+## pkgs.releaseTools
+
+**File:** `pkgs/build-support/release/default.nix` (211 lines)
+
+This module provides tools for creating release artifacts.
+
+## aggregate Function
+
+Creates a Hydra aggregate job that succeeds only if all constituents succeed:
+
+```nix
+aggregate = { name, constituents, meta ? { } }:
+  pkgs.runCommand name
+    {
+      inherit constituents meta;
+      preferLocalBuild = true;
+      _hydraAggregate = true;
+    }
+    ''
+      mkdir -p $out/nix-support
+      touch $out/nix-support/hydra-build-products
+      echo $constituents > $out/nix-support/hydra-aggregate-constituents
+
+      # Propagate build failures
+      for i in $constituents; do
+        if [ -e $i/nix-support/failed ]; then
+          touch $out/nix-support/failed
+        fi
+      done
+    '';
+```
+
+### Key Attributes
+
+- `_hydraAggregate = true` - Signals to Hydra this is an aggregate job
+- `constituents` - List of derivations that must all succeed
+- Creates `nix-support/hydra-aggregate-constituents` for Hydra to parse
+- Propagates failures via `nix-support/failed` marker
+
+### Usage Example
+
+```nix
+# From release.nix
+unstable = pkgs.releaseTools.aggregate {
+  name = "nixpkgs-${jobs.tarball.version}";
+  meta.description = "Release-critical builds for the Nixpkgs unstable channel";
+  constituents = [
+    jobs.tarball
+    jobs.release-checks
+    jobs.metrics
+    jobs.stdenv.x86_64-linux
+    jobs.nix.x86_64-linux
+    jobs.python3.x86_64-linux
+    # ...
+  ];
+};
+```
+
+## channel Function
+
+Creates a Hydra channel artifact with source tarball:
+
+```nix
+channel = { name, src, constituents ? [ ], meta ? { }, isNixOS ? true, ... }@args:
+  stdenv.mkDerivation ({
+    preferLocalBuild = true;
+    _hydraAggregate = true;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    patchPhase = optionalString isNixOS ''
+      touch .update-on-nixos-rebuild
+    '';
+
+    installPhase = ''
+      mkdir -p $out/{tarballs,nix-support}
+
+      tar cJf "$out/tarballs/nixexprs.tar.xz" \
+        --owner=0 --group=0 --mtime="1970-01-01 00:00:00 UTC" \
+        --transform='s!^\.!${name}!' .
+
+      echo "channel - $out/tarballs/nixexprs.tar.xz" > "$out/nix-support/hydra-build-products"
+      echo $constituents > "$out/nix-support/hydra-aggregate-constituents"
+
+      # Propagate build failures
+      for i in $constituents; do
+        if [ -e "$i/nix-support/failed" ]; then
+          touch "$out/nix-support/failed"
+        fi
+      done
+    '';
+
+    meta = meta // {
+      isHydraChannel = true;
+    };
+  } // removeAttrs args [ "meta" ]);
+```
+
+### Hydra Build Products
+
+The `nix-support/hydra-build-products` file tells Hydra what artifacts to
+expose. Format: `<type> <subtype> <path>`
+
+```
+channel - $out/tarballs/nixexprs.tar.xz
+file json-br $out/packages.json.br
+```
+
+## hydraJob Handling of Aggregates
+
+From `lib/customisation.nix`, aggregates are specially handled:
+
+```nix
+hydraJob = drv:
+  let
+    commonAttrs = {
+      inherit (drv) name system meta;
+      inherit outputs;
+    }
+    // optionalAttrs (drv._hydraAggregate or false) {
+      _hydraAggregate = true;
+      constituents = map hydraJob (flatten drv.constituents);
+    }
+    // (listToAttrs outputsList);
+    # ...
+  in
+  # ...
+```
+
+The `constituents` are recursively wrapped with `hydraJob` to ensure memory
+efficiency throughout.
+
+## Aggregate Job Examples
+
+### darwin-tested
+
+Gates Darwin channel updates:
+
+```nix
+darwin-tested = pkgs.releaseTools.aggregate {
+  name = "nixpkgs-darwin-${jobs.tarball.version}";
+  meta.description = "Release-critical builds for the Nixpkgs darwin channel";
+  constituents = [
+    jobs.tarball
+    jobs.release-checks
+  ]
+  ++ optionals supportDarwin.x86_64 [
+    jobs.ghc.x86_64-darwin
+    jobs.git.x86_64-darwin
+    jobs.nix.x86_64-darwin
+    jobs.python3.x86_64-darwin
+    jobs.rustc.x86_64-darwin
+    # UI apps
+    jobs.inkscape.x86_64-darwin
+    jobs.emacs.x86_64-darwin
+    # ...
+  ]
+  ++ optionals supportDarwin.aarch64 [
+    # Similar list for aarch64-darwin
+  ];
+};
+```
+
+### Haskell mergeable
+
+From `release-haskell.nix`:
+
+```nix
+mergeable = pkgs.releaseTools.aggregate {
+  name = "haskell-updates-mergeable";
+  meta = {
+    description = ''
+      Critical haskell packages that should work at all times,
+      serves as minimum requirement for an update merge
+    '';
+    teams = [ lib.teams.haskell ];
+  };
+  constituents = accumulateDerivations [
+    jobs.tests.haskell
+    jobs.cabal-install
+    jobs.pandoc
+    jobs.stack
+    jobs.haskellPackages.xmonad
+    # ...
+  ];
+};
+```
+
+### NixOS tested
+
+From `nixos/release-combined.nix`:
+
+```nix
+tested = pkgs.releaseTools.aggregate {
+  name = "nixos-${nixos.channel.version}";
+  meta = {
+    description = "Release-critical builds for the NixOS channel";
+  };
+  constituents = pkgs.lib.concatLists [
+    [ "nixos.channel" ]
+    (onFullSupported "nixos.dummy")
+    (onAllSupported "nixos.iso_minimal")
+    (onFullSupported "nixos.tests.login")
+    (onFullSupported "nixos.tests.openssh")
+    (onFullSupported "nixos.tests.gnome")
+    # ... many more tests
+    [ "nixpkgs.tarball" "nixpkgs.release-checks" ]
+  ];
+};
+```
+
+## Helper: accumulateDerivations
+
+From `release-haskell.nix`, flattens nested job structures for aggregate
+constituents:
+
+```nix
+accumulateDerivations = jobList:
+  lib.concatMap (attrs:
+    if lib.isDerivation attrs then
+      [ attrs ]
+    else
+      lib.optionals (lib.isAttrs attrs)
+        (accumulateDerivations (lib.attrValues attrs))
+  ) jobList;
+```
+
+This allows:
+```nix
+constituents = accumulateDerivations [
+  jobs.tests.haskell  # Nested attrset of tests
+  jobs.pandoc         # Single derivation
+  jobs.haskellPackages.lens  # From package set
+];
+```
+
+## Other Release Tools
+
+### sourceTarball
+
+Creates reproducible source tarballs:
+
+```nix
+sourceTarball = args:
+  import ./source-tarball.nix ({
+    inherit lib stdenv autoconf automake libtool;
+  } // args);
+```
+
+### binaryTarball
+
+Creates binary distribution tarballs:
+
+```nix
+binaryTarball = args:
+  import ./binary-tarball.nix ({
+    inherit lib stdenv;
+  } // args);
+```
+
+### nixBuild
+
+Wrapper for standard nix builds with release metadata:
+
+```nix
+nixBuild = args:
+  import ./nix-build.nix ({
+    inherit lib stdenv;
+  } // args);
+```
+
+### Coverage and Analysis
+
+```nix
+coverageAnalysis = args:
+  nixBuild ({
+    inherit lcov enableGCOVInstrumentation makeGCOVReport;
+    doCoverageAnalysis = true;
+  } // args);
+
+clangAnalysis = args:
+  nixBuild ({
+    inherit clang-analyzer;
+    doClangAnalysis = true;
+  } // args);
+```

--- a/doc/nixpkgs-ci/07-ci-eval.md
+++ b/doc/nixpkgs-ci/07-ci-eval.md
@@ -1,0 +1,376 @@
+# CI Evaluation Infrastructure
+
+This document covers the GitHub Actions-based evaluation infrastructure in
+`ci/eval/`.
+
+## Overview
+
+The `ci/eval/` directory contains a parallel evaluation system used by GitHub
+Actions to detect package changes and regressions in PRs.
+
+## Architecture
+
+```
+┌────────────────────────┐
+│   attrpaths.nix        │  Fast single-threaded enumeration
+│   (superset of attrs)  │  of all possible job attrpaths
+└───────────┬────────────┘
+            │
+            ▼
+┌────────────────────────┐
+│   chunk.nix            │  Splits attrpaths into N chunks
+│   (parallel chunks)    │  for parallel evaluation
+└───────────┬────────────┘
+            │
+            ▼
+┌────────────────────────┐
+│   outpaths.nix         │  Evaluates release.nix with
+│   (actual eval)        │  custom config for CI
+└───────────┬────────────┘
+            │
+            ▼
+┌────────────────────────┐
+│   default.nix          │  Orchestrates chunked evaluation
+│   (orchestration)      │  and comparison
+└───────────┬────────────┘
+            │
+            ▼
+┌────────────────────────┐
+│   diff.nix / compare/  │  Compares before/after,
+│   (analysis)           │  generates reports
+└────────────────────────┘
+```
+
+## attrpaths.nix
+
+**Purpose:** Quickly enumerate all derivation attrpaths without fully
+evaluating them.
+
+```nix
+{
+  lib ? import (path + "/lib"),
+  trace ? false,
+  path ? ./../..,
+  extraNixpkgsConfigJson ? "{}",
+}:
+let
+  justAttrNames = path: value:
+    let
+      result =
+        if path == [ "AAAAAASomeThingsFailToEvaluate" ] || !(lib.isAttrs value) then
+          [ ]
+        else if lib.isDerivation value then
+          [ path ]
+        else
+          lib.pipe value [
+            (lib.mapAttrsToList (name: value:
+              lib.addErrorContext "while evaluating package set attribute path '${
+                lib.showAttrPath (path ++ [ name ])
+              }'" (justAttrNames (path ++ [ name ]) value)
+            ))
+            lib.concatLists
+          ];
+    in
+    lib.traceIf trace "** ${lib.showAttrPath path}" result;
+
+  outpaths = import ./outpaths.nix {
+    inherit path;
+    extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
+    attrNamesOnly = true;  # Key optimization
+  };
+
+  # Manually add variant stdenvs that are disabled with attrNamesOnly
+  paths = [
+    [ "pkgsLLVM" "stdenv" ]
+    [ "pkgsArocc" "stdenv" ]
+    [ "pkgsZig" "stdenv" ]
+    [ "pkgsStatic" "stdenv" ]
+    [ "pkgsMusl" "stdenv" ]
+  ] ++ justAttrNames [ ] outpaths;
+
+  names = map lib.showAttrPath paths;
+in
+{ inherit paths names; }
+```
+
+**Usage:**
+```bash
+nix-instantiate --eval --strict --json ci/eval/attrpaths.nix -A names
+```
+
+## outpaths.nix
+
+**Purpose:** Evaluate release.nix with CI-specific configuration.
+
+```nix
+{
+  includeBroken ? true,
+  path ? ./../..,
+  attrNamesOnly ? false,
+  systems ? builtins.fromJSON (builtins.readFile ../supportedSystems.json),
+  extraNixpkgsConfig ? { },
+}:
+let
+  nixpkgsJobs = import (path + "/pkgs/top-level/release.nix") {
+    inherit attrNamesOnly;
+    supportedSystems = if systems == null then [ builtins.currentSystem ] else systems;
+    nixpkgsArgs = {
+      config = {
+        allowAliases = false;
+        allowBroken = includeBroken;
+        allowUnfree = true;
+        allowInsecurePredicate = x: true;
+        allowVariants = !attrNamesOnly;
+        checkMeta = true;
+
+        handleEvalIssue = reason: errormsg:
+          let
+            fatalErrors = [ "unknown-meta" "broken-outputs" ];
+          in
+          if builtins.elem reason fatalErrors then
+            abort errormsg
+          else if !includeBroken && builtins.elem reason [ "broken" "unfree" ] then
+            throw "broken"
+          else if builtins.elem reason [ "unsupported" ] then
+            throw "unsupported"
+          else
+            true;
+
+        inHydra = true;
+      } // extraNixpkgsConfig;
+      __allowFileset = false;
+    };
+  };
+
+  nixosJobs = import (path + "/nixos/release.nix") {
+    inherit attrNamesOnly;
+    supportedSystems = ...;
+  };
+
+  # Blacklist jobs that don't work well with CI eval
+  blacklist = [
+    "tarball" "metrics" "manual" "darwin-tested"
+    "unstable" "stdenvBootstrapTools" "moduleSystem" "lib-tests"
+  ];
+
+  # Ensure recurseForDerivations is set properly
+  tweak = lib.mapAttrs (name: val:
+    if name == "recurseForDerivations" then true
+    else if lib.isAttrs val && val.type or null != "derivation" then
+      recurseIntoAttrs (tweak val)
+    else val
+  );
+in
+tweak ((removeAttrs nixpkgsJobs blacklist) // {
+  nixosTests.simple = nixosJobs.tests.simple;
+})
+```
+
+## chunk.nix
+
+**Purpose:** Split evaluation into parallel chunks.
+
+```nix
+{
+  lib ? import ../../lib,
+  path ? ../..,
+  attrpathFile,
+  chunkSize,
+  myChunk,
+  includeBroken,
+  systems,
+  extraNixpkgsConfigJson,
+}:
+let
+  attrpaths = lib.importJSON attrpathFile;
+  myAttrpaths = lib.sublist (chunkSize * myChunk) chunkSize attrpaths;
+
+  unfiltered = import ./outpaths.nix {
+    inherit path includeBroken systems;
+    extraNixpkgsConfig = builtins.fromJSON extraNixpkgsConfigJson;
+  };
+
+  # Filter to only our chunk's attrpaths
+  filtered =
+    let
+      recurse = index: paths: attrs:
+        lib.mapAttrs (name: values:
+          if attrs ? ${name} then
+            if lib.any (value: lib.length value <= index + 1) values then
+              attrs.${name}
+            else
+              recurse (index + 1) values attrs.${name}
+              // { recurseForDerivations = true; }
+          else
+            null
+        ) (lib.groupBy (a: lib.elemAt a index) paths);
+    in
+    recurse 0 myAttrpaths unfiltered;
+in
+filtered
+```
+
+## default.nix (Orchestration)
+
+**Purpose:** Coordinate the evaluation process.
+
+### attrpathsSuperset
+
+Generate the list of all attrpaths:
+
+```nix
+attrpathsSuperset = { evalSystem }:
+  runCommand "attrpaths-superset.json" {
+    src = nixpkgs;
+    nativeBuildInputs = [ busybox nix ];
+  } ''
+    export NIX_STATE_DIR=$(mktemp -d)
+    mkdir $out
+    export GC_INITIAL_HEAP_SIZE=4g
+    nix-instantiate --eval --strict --json --show-trace \
+      "$src/ci/eval/attrpaths.nix" \
+      -A paths \
+      --option restrict-eval true \
+      --option allow-import-from-derivation false \
+      --option eval-system "${evalSystem}" > $out/paths.json
+  '';
+```
+
+### singleSystem
+
+Evaluate all packages for one system in parallel chunks:
+
+```nix
+singleSystem = { evalSystem, attrpathFile }:
+  let
+    singleChunk = writeShellScript "single-chunk" ''
+      set -euo pipefail
+      chunkSize=$1
+      myChunk=$2
+      system=$3
+      outputDir=$4
+
+      export GC_LARGE_ALLOC_WARN_INTERVAL=1000
+      export NIX_SHOW_STATS=1
+      export NIX_SHOW_STATS_PATH="$outputDir/stats/$myChunk"
+
+      nix-env -f "${nixpkgs}/ci/eval/chunk.nix" \
+        --eval-system "$system" \
+        --option restrict-eval true \
+        --option allow-import-from-derivation false \
+        --query --available --out-path --json --meta --show-trace \
+        --arg chunkSize "$chunkSize" \
+        --arg myChunk "$myChunk" \
+        --arg attrpathFile "${attrpathFile}" \
+        > "$outputDir/result/$myChunk"
+    '';
+  in
+  runCommand "nixpkgs-eval-${evalSystem}" { ... } ''
+    # Parallel chunk evaluation using xargs
+    seq -w 0 "$seq_end" |
+      xargs -I{} -P"$cores" ${singleChunk} "$chunkSize" {} "$evalSystem" "$chunkOutputDir"
+
+    # Combine results
+    cat "$chunkOutputDir"/result/* | jq -s 'add | map_values(.outputs)' > $out/paths.json
+    cat "$chunkOutputDir"/result/* | jq -s 'add | map_values(.meta)' > $out/meta.json
+  '';
+```
+
+### full
+
+Complete evaluation with before/after comparison:
+
+```nix
+full = { evalSystems, baseline, touchedFilesJson }:
+  let
+    diffs = symlinkJoin {
+      name = "nixpkgs-eval-diffs";
+      paths = map (evalSystem:
+        diff {
+          inherit evalSystem;
+          beforeDir = baseline;
+          afterDir = singleSystem { inherit evalSystem; };
+        }
+      ) evalSystems;
+    };
+    comparisonReport = compare {
+      combinedDir = combine { diffDir = diffs; };
+      inherit touchedFilesJson;
+    };
+  in
+  comparisonReport;
+```
+
+## diff.nix
+
+Compares before/after evaluation results:
+
+```nix
+{
+  evalSystem,
+  beforeDir,
+  afterDir,
+}:
+runCommand "nixpkgs-eval-diff-${evalSystem}" { ... } ''
+  # Generate diff of changed packages
+  jq -s '
+    {
+      added: (.[1] | keys) - (.[0] | keys),
+      removed: (.[0] | keys) - (.[1] | keys),
+      changed: [
+        (.[0] | to_entries[]) as $before |
+        (.[1][$before.key]) as $after |
+        select($after != null and $after != $before.value) |
+        $before.key
+      ],
+      rebuilds: ...
+    }
+  ' "${beforeDir}/paths.json" "${afterDir}/paths.json" > $out/diff.json
+'';
+```
+
+## compare/
+
+Generates human-readable comparison reports:
+
+- `compare/default.nix` - Main comparison logic
+- `compare/maintainers.nix` - Extract affected maintainers
+- `compare/utils.nix` - Helper functions
+
+## Evaluation Constraints
+
+The CI evaluation uses strict constraints:
+
+```nix
+--option restrict-eval true
+--option allow-import-from-derivation false
+```
+
+This ensures:
+- No access to files outside the source tree
+- No IFD (import-from-derivation) which would require building
+- Reproducible, sandboxed evaluation
+
+## Memory Management
+
+```nix
+# Increase GC threshold to reduce GC pauses
+export GC_LARGE_ALLOC_WARN_INTERVAL=1000
+
+# Pre-size the heap
+export GC_INITIAL_HEAP_SIZE=4g
+
+# Collect stats for analysis
+export NIX_SHOW_STATS=1
+export NIX_SHOW_STATS_PATH="$outputDir/stats/$myChunk"
+```
+
+## Chunk Size
+
+Default chunk size is 5000 attributes:
+
+```nix
+chunkSize ? 5000,
+```
+
+With ~100,000 packages, this means ~20 parallel evaluation jobs per system.

--- a/doc/nixpkgs-ci/08-attrset-structure.md
+++ b/doc/nixpkgs-ci/08-attrset-structure.md
@@ -1,0 +1,295 @@
+# Resulting Attrset Structure
+
+This document describes the structure of the attribute set produced by
+nixpkgs release files for Hydra consumption.
+
+## Basic Structure
+
+After evaluation, release.nix produces an attrset like:
+
+```nix
+{
+  # Non-package special jobs
+  tarball = <drv>;
+  release-checks = <drv>;
+  manual = <drv>;
+  metrics = <drv>;
+
+  # Aggregate gates
+  unstable = <aggregate-drv>;
+  darwin-tested = <aggregate-drv>;
+
+  # Bootstrap tools by platform
+  stdenvBootstrapTools = {
+    "aarch64-unknown-linux-gnu" = { build = <drv>; test = <drv>; };
+    "x86_64-unknown-linux-gnu" = { build = <drv>; test = <drv>; };
+    "arm64-apple-darwin" = { build = <drv>; test = <drv>; };
+    # ...
+  };
+
+  # Package jobs: attrpath.system = drv
+  hello = {
+    x86_64-linux = <drv>;
+    aarch64-linux = <drv>;
+    x86_64-darwin = <drv>;
+    aarch64-darwin = <drv>;
+  };
+
+  # Nested package sets
+  pythonPackages = {
+    requests = {
+      x86_64-linux = <drv>;
+      aarch64-linux = <drv>;
+    };
+    numpy = {
+      x86_64-linux = <drv>;
+      # ...
+    };
+  };
+
+  # Haskell multi-compiler
+  haskell = {
+    compiler = {
+      ghc948 = { x86_64-linux = <drv>; ... };
+      ghc9122 = { x86_64-linux = <drv>; ... };
+    };
+    packages = {
+      ghc96 = {
+        haskell-language-server = { x86_64-linux = <drv>; ... };
+      };
+      ghc98 = { ... };
+    };
+  };
+
+  # Alternative toolchains
+  pkgsLLVM = { stdenv = { x86_64-linux = <drv>; aarch64-linux = <drv>; }; };
+  pkgsMusl = { stdenv = { x86_64-linux = <drv>; aarch64-linux = <drv>; }; };
+
+  # Tests
+  tests = {
+    lib-tests = { x86_64-linux = <drv>; };
+    cc-wrapper = {
+      default = { x86_64-linux = <drv>; ... };
+      llvmPackages.clang = { x86_64-linux = <drv>; ... };
+    };
+  };
+}
+```
+
+## Hydra Job Naming
+
+Hydra flattens the attrset to job names using dot notation:
+
+| Attrpath | Hydra Job Name |
+|----------|----------------|
+| `hello.x86_64-linux` | `hello.x86_64-linux` |
+| `pythonPackages.requests.x86_64-linux` | `pythonPackages.requests.x86_64-linux` |
+| `haskell.compiler.ghc948.x86_64-linux` | `haskell.compiler.ghc948.x86_64-linux` |
+
+## Job Types
+
+### Regular Package Jobs
+
+Structure: `attrpath.system = derivation`
+
+```nix
+hello.x86_64-linux = derivation {
+  name = "hello-2.12.1";
+  system = "x86_64-linux";
+  meta = { ... };
+  outputs = [ "out" ];
+  # When scrubJobs = true, only essential attrs remain
+};
+```
+
+### Aggregate Jobs
+
+Structure: `aggregate = derivation with _hydraAggregate = true`
+
+```nix
+unstable = derivation {
+  name = "nixpkgs-24.11pre...";
+  _hydraAggregate = true;
+  constituents = [ <drv> <drv> ... ];
+  meta.description = "Release-critical builds for the Nixpkgs unstable channel";
+};
+```
+
+### Channel Jobs
+
+Structure: `channel = derivation with isHydraChannel = true`
+
+```nix
+channel = derivation {
+  name = "nixos-24.11pre...";
+  meta.isHydraChannel = true;
+  # Contains nixexprs.tar.xz
+};
+```
+
+## NixOS release.nix Structure
+
+```nix
+{
+  channel = <channel-drv>;
+
+  # Documentation
+  manualHTML = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+  manualEpub = { ... };
+  options = <drv>;  # Only x86_64-linux
+
+  # Installation media
+  iso_minimal = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+  iso_graphical = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+
+  # SD images (ARM only)
+  sd_image = {
+    armv6l-linux = <drv>;
+    armv7l-linux = <drv>;
+    aarch64-linux = <drv>;
+  };
+
+  # Cloud images
+  amazonImage = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+  proxmoxImage = { x86_64-linux = <drv>; };
+
+  # Network boot
+  netboot = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+  kexec = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+
+  # Tests (very large)
+  tests = {
+    login = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+    openssh = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+    gnome = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+    # ... hundreds of tests
+    allDrivers = {
+      login = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+      # ... test drivers (faster to eval)
+    };
+  };
+
+  # Closure size tracking
+  closures = {
+    smallContainer = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+    kde = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+    gnome = { x86_64-linux = <drv>; aarch64-linux = <drv>; };
+  };
+}
+```
+
+## attrNamesOnly Mode
+
+When `attrNamesOnly = true`, the structure changes for CI optimization:
+
+```nix
+# Normal mode
+hello = {
+  x86_64-linux = <drv>;
+  aarch64-linux = <drv>;
+};
+
+# attrNamesOnly mode
+hello = <drv>;  # Just one representative derivation
+```
+
+This reduces memory usage dramatically for attrpath enumeration.
+
+## recurseForDerivations
+
+Package sets use this marker to indicate Hydra/nix-env should recurse:
+
+```nix
+pythonPackages = {
+  recurseForDerivations = true;  # Essential marker
+  requests = { x86_64-linux = <drv>; };
+  numpy = { x86_64-linux = <drv>; };
+};
+```
+
+Without this, nested package sets would be ignored.
+
+## recurseForRelease
+
+Similar to `recurseForDerivations`, but specifically for release evaluation:
+
+```nix
+somePackageSet = {
+  recurseForRelease = true;
+  # ...
+};
+```
+
+Checked in `release-lib.nix`:
+```nix
+recursiveMapPackages = f:
+  mapAttrs (name: value:
+    if isDerivation value then f value
+    else if value.recurseForDerivations or false
+         || value.recurseForRelease or false then
+      recursiveMapPackages f value
+    else [ ]
+  );
+```
+
+## Platform Filtering Result
+
+The `packagePlatforms` function produces:
+
+```nix
+# Input: pkgs attrset
+# Output: attrset of platform lists
+
+{
+  hello = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+  pythonPackages = {
+    requests = [ "aarch64-linux" "x86_64-linux" ];
+    # numpy might be linux-only
+    numpy = [ "aarch64-linux" "x86_64-linux" ];
+  };
+  linuxPackages = {
+    perf = [ "aarch64-linux" "x86_64-linux" ];  # Linux only
+  };
+}
+```
+
+Then `mapTestOn` transforms this to derivations by system.
+
+## Stripped Derivation Attributes
+
+When `scrubJobs = true`, `hydraJob` strips derivations to:
+
+```nix
+{
+  # Preserved
+  name = "hello-2.12.1";
+  system = "x86_64-linux";
+  outputs = [ "out" ];
+  out = {
+    outPath = "/nix/store/...";
+    drvPath = "/nix/store/....drv";
+  };
+  meta = {
+    # All meta preserved
+    description = "...";
+    license = lib.licenses.gpl3Plus;
+    platforms = [ ... ];
+    maintainers = [ ... ];
+    # ...
+  };
+
+  # For aggregates only
+  _hydraAggregate = true;
+  constituents = [ ... ];
+
+  # STRIPPED (not present):
+  # - src
+  # - buildInputs
+  # - nativeBuildInputs
+  # - buildPhase
+  # - installPhase
+  # - All other build-time attributes
+}
+```
+
+This dramatically reduces memory during evaluation.

--- a/doc/nixpkgs-ci/09-passthru-tests.md
+++ b/doc/nixpkgs-ci/09-passthru-tests.md
@@ -1,0 +1,248 @@
+# Passthru Tests
+
+This document covers how `passthru.tests` is handled in nixpkgs CI.
+
+## Overview
+
+`passthru.tests` is a convention for associating test derivations with
+packages. These tests verify the package works correctly but are evaluated
+separately from the main package build.
+
+## Definition
+
+From `doc/stdenv/passthru.chapter.md`:
+
+```nix
+stdenv.mkDerivation {
+  pname = "my-package";
+  # ...
+
+  passthru.tests = {
+    basic = runCommand "test-my-package" { } ''
+      ${my-package}/bin/my-program --version
+      touch $out
+    '';
+
+    # NixOS VM tests
+    nixos-integration = nixosTests.myPackage;
+  };
+}
+```
+
+## CI Behavior
+
+### Hydra
+
+**Hydra does NOT build `passthru.tests` by default.**
+
+From the documentation:
+> The Nixpkgs systems for continuous integration Hydra and nixpkgs-review
+> don't build these derivations by default.
+
+`passthru.tests` are not included in the release.nix job tree because
+`packagePlatforms` only looks at derivations themselves, not their passthru:
+
+```nix
+# From release-lib.nix
+recursiveMapPackages = f:
+  mapAttrs (name: value:
+    if isDerivation value then
+      f value  # Only processes the derivation, not passthru
+    else if value.recurseForDerivations or false then
+      recursiveMapPackages f value
+    else
+      [ ]
+  );
+```
+
+### ofBorg
+
+**ofBorg DOES build `passthru.tests` for changed packages.**
+
+From the documentation:
+> ofborg only builds them when evaluating pull requests for that particular
+> package, or when manually instructed.
+
+When a package is modified in a PR, ofBorg:
+1. Identifies the changed package
+2. Builds the package itself
+3. Also builds `passthru.tests` for that package
+
+### nixpkgs-review
+
+Similarly, `nixpkgs-review` builds `passthru.tests` for packages it's testing.
+
+## NixOS Tests as passthru.tests
+
+A common pattern is linking NixOS VM tests:
+
+```nix
+{ nixosTests, ... }:
+stdenv.mkDerivation {
+  pname = "opensmtpd";
+  # ...
+  passthru.tests = {
+    basic-functionality = nixosTests.opensmtpd;
+  };
+}
+```
+
+The `nixosTests` argument provides access to all tests from
+`nixos/tests/all-tests.nix`.
+
+## all-tests.nix Structure
+
+**File:** `nixos/tests/all-tests.nix`
+
+This file discovers and wraps all NixOS tests:
+
+```nix
+{ system, pkgs, callTest }:
+let
+  discoverTests = val:
+    if isAttrs val then
+      if (val ? test) then
+        callTest val
+      else
+        mapAttrs (n: s: if n == "passthru" then s else discoverTests s) val
+    else if isFunction val then
+      discoverTests (val { inherit system pkgs; })
+    else
+      val;
+
+  # Helper for legacy test format
+  handleTest = path: args:
+    discoverTests (import path ({ inherit system pkgs; } // args));
+in
+{
+  # Tests are listed here
+  login = runTest ./login.nix;
+  openssh = runTest ./openssh.nix;
+  # ...
+}
+```
+
+Note the `passthru` handling:
+```nix
+mapAttrs (n: s: if n == "passthru" then s else discoverTests s) val
+```
+
+This **skips** recursing into `passthru` attributes, preventing
+`passthru.tests` from being accidentally included in the NixOS test suite.
+
+## Test Platform Handling
+
+Tests from `passthru.tests` respect the platform of the parent package:
+
+```nix
+# Package only on Linux
+meta.platforms = lib.platforms.linux;
+
+passthru.tests = {
+  # This test would only make sense on Linux
+  basic = runCommand "test" { } "...";
+};
+```
+
+For NixOS tests linked via `nixosTests`, they're naturally Linux-only since
+they run in VMs.
+
+## Empty Tests for Unsupported Platforms
+
+From `nixos/tests/all-tests.nix`:
+
+```nix
+# The tests not supported by `system` will be replaced with `{}`, so that
+# `passthru.tests` can contain links to those without breaking on architectures
+# where said tests are unsupported.
+```
+
+This means:
+```nix
+passthru.tests = {
+  # On aarch64-darwin, this might evaluate to {}
+  # instead of failing
+  nixos-integration = nixosTests.myPackage;
+};
+```
+
+## Explicit Test Jobs
+
+Some release files DO include specific tests:
+
+```nix
+# From release-haskell.nix
+(mapTestOn {
+  tests.haskell = packagePlatforms pkgs.tests.haskell;
+  nixosTests = {
+    agda = packagePlatforms pkgs.nixosTests.agda;
+    inherit (packagePlatforms pkgs.nixosTests) kmonad xmonad;
+  };
+})
+```
+
+These are explicitly added to the jobset, separate from `passthru.tests`.
+
+## Building passthru.tests Manually
+
+```bash
+# Build all tests for a package
+nix-build -A myPackage.tests
+
+# Build a specific test
+nix-build -A myPackage.tests.basic
+
+# Using nix build
+nix build .#myPackage.tests.basic
+```
+
+## versionCheckHook vs passthru.tests
+
+The documentation recommends `versionCheckHook` over `passthru.tests` for
+simple version checks:
+
+```nix
+# Preferred: runs during installCheckPhase
+nativeInstallCheckInputs = [ versionCheckHook ];
+
+# Alternative: as a passthru test
+passthru.tests.version = testers.testVersion { package = my-package; };
+```
+
+Advantages of `versionCheckHook`:
+- Runs automatically during build
+- Failure blocks the build
+- No extra CI configuration needed
+
+## Meta Attribute Validation
+
+The `check-meta.nix` validates test structure:
+
+```nix
+metaTypes = {
+  # ...
+  tests = {
+    name = "test";
+    verify = x:
+      x == { }  # Empty attrset (unsupported platform)
+      || (isDerivation x && x ? meta.timeout);
+  };
+  # ...
+};
+```
+
+Note: This validates `meta.tests`, not `passthru.tests`. The `meta.tests`
+attribute is largely deprecated in favor of `passthru.tests`.
+
+## Summary
+
+| CI System | Builds passthru.tests? | When? |
+|-----------|------------------------|-------|
+| Hydra | No | Never by default |
+| ofBorg | Yes | For changed packages in PRs |
+| nixpkgs-review | Yes | For reviewed packages |
+| Manual | Yes | When explicitly requested |
+
+The key insight is that `passthru.tests` provides **on-demand testing** rather
+than **always-on CI testing**. This keeps Hydra build load manageable while
+still allowing comprehensive testing when packages change.


### PR DESCRIPTION
## Summary

- Comprehensive research and documentation on how nixpkgs structures its nix code for Hydra CI evaluation and builds
- 9 markdown documents covering all aspects of the evaluation system
- Includes accurate code citations from the nixpkgs source

## Documents

1. **Overview** - High-level architecture and file index
2. **Release Entrypoints** - Main release.nix files (nixpkgs, nixos, cross, haskell, etc.)
3. **Release Library** - Core functions: mapTestOn, packagePlatforms, getPlatforms, memoization
4. **Platform Filtering** - meta.platforms, meta.hydraPlatforms, meta.badPlatforms resolution
5. **Eval Error Handling** - checkMeta, handleEvalIssue, validity checks
6. **Job Aggregation** - releaseTools.aggregate, channel jobs, constituents
7. **CI Eval Infrastructure** - GitHub Actions chunked evaluation system
8. **Resulting Attrset Structure** - Final job tree layout for Hydra
9. **Passthru Tests** - How passthru.tests is (not) handled by Hydra vs ofBorg

## Key Findings

- `pkgs/top-level/release.nix` is the main entrypoint
- `release-lib.nix` provides memoized package sets and platform mapping
- Platform resolution: `meta.hydraPlatforms || (meta.platforms - meta.badPlatforms)`
- `hydraJob` strips non-essential derivation attributes to save memory
- `passthru.tests` is NOT built by Hydra but IS built by ofBorg for changed packages
- CI eval uses chunked parallel evaluation for performance

## Test plan

- [x] Documentation compiles and renders correctly
- [x] Code citations verified against nixpkgs source